### PR TITLE
chore: Update for trestle 0.10

### DIFF
--- a/trestle-active_storage.gemspec
+++ b/trestle-active_storage.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'rails', '>= 5.2'
-  s.add_dependency "trestle", "~> 0.9.0", ">= 0.9.3"
+  s.add_dependency "trestle", "~> 0.10.0"
 end


### PR DESCRIPTION
https://github.com/richardvenneman/trestle-active_storage/pull/125 says that it works with 0.10 without changes.

This will unblock upgrading to trestle 0.10 and might fix these annoying renovatebot maintenance PRs that list but do not update trestle (because blocked by this git dependency).